### PR TITLE
修复发送邮件失败的错误

### DIFF
--- a/tickets_polls/base/u_database.py
+++ b/tickets_polls/base/u_database.py
@@ -17,7 +17,7 @@ def setup_database(app: Application) -> None:
     uri = 'mongodb://'
     if conf['database']['user'] != '':
         uri += '{}:{}@'.format(quote_plus(conf['database']['user']), quote_plus(conf['database']['pass']))
-    uri += '{}:{}'.format(quote_plus(conf['database']['host']), quote_plus(conf['database']['port']))
+    uri += '{}:{}'.format(quote_plus(conf['database']['host']), conf['database']['port'])
     uri += '/{}'.format(quote_plus(conf['database']['name']))
     client = AsyncIOMotorClient(uri)
     app['db'] = client.get_database(quote_plus(conf['database']['name']))

--- a/tickets_polls/config.py
+++ b/tickets_polls/config.py
@@ -31,7 +31,7 @@ def load_private_key(pem_key, password=None):
 def load_config(config_path):
     with open(config_path, 'r', encoding='utf-8') as f:
         cfg = f.read()
-        config = yaml.load(cfg, Loader=yaml.BaseLoader)  # 用load方法转字典
+        config = yaml.load(cfg, Loader=yaml.FullLoader)  # 用load方法转字典
     return config
 
 


### PR DESCRIPTION
**原因：**
腾讯云不允许使用25端口发送邮件，并且不允许由服务器直接发送邮件。

**解决：**
使用465端口通过中转服务发送
        